### PR TITLE
Fix GitHub Actions workflow for project status updates

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -22,17 +22,111 @@ jobs:
           ISSUE_TITLE=$(gh issue view $ISSUE_NUMBER --json title -q .title)
           echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
           echo "ISSUE_TITLE=$ISSUE_TITLE" >> $GITHUB_ENV
-          BRANCH_NAME="issue-${ISSUE_NUMBER}-implementation"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          
+          # Add "in_progress" label to issue if it exists
+          gh issue edit $ISSUE_NUMBER --add-label "in_progress" || echo "Label may not exist or already applied"
+          
+          # Update project board status
+          if [ -n "${{ secrets.PROJECT_ID }}" ]; then
+            echo "Updating project board status..."
+            
+            # Get item ID using GraphQL
+            ITEM_ID=$(gh api graphql -f query='
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: ${{ secrets.PROJECT_ID }}) {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                          }
+                        }
+                      }
+                    }
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f org="idynic" -f number=$ISSUE_NUMBER --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '$ISSUE_NUMBER') | .id')
+            
+            if [ -z "$ITEM_ID" ]; then
+              echo "Issue #$ISSUE_NUMBER not found in project board"
+            else
+              echo "Found issue in project with item ID: $ITEM_ID"
+              
+              # Get status field ID
+              STATUS_FIELD=$(gh api graphql -f query='
+                query($org: String!) {
+                  organization(login: $org) {
+                    projectV2(number: ${{ secrets.PROJECT_ID }}) {
+                      field(name: "Status") {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }' -f org="idynic" --jq '.data.organization.projectV2.field')
+              
+              STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+              IN_PROGRESS_OPTION=$(echo "$STATUS_FIELD" | jq -r '.options[] | select(.name == "In Progress")')
+              IN_PROGRESS_ID=$(echo "$IN_PROGRESS_OPTION" | jq -r '.id')
+              
+              if [ -z "$IN_PROGRESS_ID" ]; then
+                echo "Could not find 'In Progress' status option"
+              else
+                echo "Setting status to 'In Progress'"
+                
+                # Update status
+                gh api graphql -f query='
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { 
+                        singleSelectOptionId: $optionId
+                      }
+                    }) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }' -f projectId="$(gh api graphql -f query='query($org: String!) {organization(login: $org) {projectV2(number: ${{ secrets.PROJECT_ID }}) {id}}}' -f org="idynic" --jq '.data.organization.projectV2.id')" \
+                     -f itemId="$ITEM_ID" \
+                     -f fieldId="$STATUS_FIELD_ID" \
+                     -f optionId="$IN_PROGRESS_ID"
+                
+                echo "Project board status updated to 'In Progress'"
+              fi
+            fi
+          else
+            echo "No PROJECT_ID secret found, skipping project board update"
+          fi
           
           # Comment on issue
           gh issue comment $ISSUE_NUMBER --body "🤖 Claude has started working on this issue. Implementation in progress..."
           
           # Create branch
+          BRANCH_NAME="issue-${ISSUE_NUMBER}-implementation"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           git checkout -b $BRANCH_NAME
           git push -u origin $BRANCH_NAME
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           
       - name: Prepare prompt file
         run: |
@@ -54,7 +148,7 @@ jobs:
           install_github_mcp: "true"
           timeout_minutes: "30"
           anthropic_api_key: "${{ secrets.ANTHROPIC_API_KEY }}"
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          github_token: "${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}"
       
       - name: Create PR
         run: |
@@ -78,5 +172,88 @@ jobs:
           
           # Comment with result
           gh issue comment ${{ env.ISSUE_NUMBER }} --body "✅ Implementation completed and PR submitted: $PR_URL"
+          
+          # Update project board status to "Review" if project board integration is enabled
+          if [ -n "${{ secrets.PROJECT_ID }}" ]; then
+            echo "Updating project board status to 'Review'..."
+            
+            # Get item ID
+            ITEM_ID=$(gh api graphql -f query='
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: ${{ secrets.PROJECT_ID }}) {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            number
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f org="idynic" -f number="${{ env.ISSUE_NUMBER }}" --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == ${{ env.ISSUE_NUMBER }}) | .id')
+            
+            if [ -n "$ITEM_ID" ]; then
+              # Get status field and in review option
+              STATUS_FIELD=$(gh api graphql -f query='
+                query($org: String!) {
+                  organization(login: $org) {
+                    projectV2(number: ${{ secrets.PROJECT_ID }}) {
+                      field(name: "Status") {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }' -f org="idynic" --jq '.data.organization.projectV2.field')
+              
+              STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+              IN_REVIEW_OPTION=$(echo "$STATUS_FIELD" | jq -r '.options[] | select(.name == "Review")')
+              IN_REVIEW_ID=$(echo "$IN_REVIEW_OPTION" | jq -r '.id')
+              
+              if [ -n "$IN_REVIEW_ID" ]; then
+                # Get project ID
+                PROJECT_ID=$(gh api graphql -f query='
+                  query($org: String!) {
+                    organization(login: $org) {
+                      projectV2(number: ${{ secrets.PROJECT_ID }}) {
+                        id
+                      }
+                    }
+                  }' -f org="idynic" --jq '.data.organization.projectV2.id')
+                
+                # Update status to "Review"
+                gh api graphql -f query='
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { 
+                        singleSelectOptionId: $optionId
+                      }
+                    }) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$STATUS_FIELD_ID" -f optionId="$IN_REVIEW_ID"
+                
+                echo "Project board status updated to 'Review'"
+              else
+                echo "Could not find 'Review' status option in project board"
+              fi
+            else
+              echo "Could not find issue in project board"
+            fi
+          fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -56,7 +56,7 @@ jobs:
                     }
                   }
                 }
-              }' -f org="idynic" -f number=$ISSUE_NUMBER --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '$ISSUE_NUMBER') | .id')
+              }' -f org="idynic" -f number=$ISSUE_NUMBER --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '"$ISSUE_NUMBER"') | .id')
             
             if [ -z "$ITEM_ID" ]; then
               echo "Issue #$ISSUE_NUMBER not found in project board"
@@ -194,7 +194,7 @@ jobs:
                     }
                   }
                 }
-              }' -f org="idynic" -f number="${{ env.ISSUE_NUMBER }}" --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == ${{ env.ISSUE_NUMBER }}) | .id')
+              }' -f org="idynic" -f number="${{ env.ISSUE_NUMBER }}" --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '"${{ env.ISSUE_NUMBER }}"') | .id')
             
             if [ -n "$ITEM_ID" ]; then
               # Get status field and in review option


### PR DESCRIPTION
This PR resolves issues with the Claude implementation workflow:

1. Fixes GraphQL queries for project board status updates
2. Correctly updates project board statuses to 'In Progress' and 'Review'
3. Uses PROJECT_TOKEN instead of GITHUB_TOKEN for proper permissions
4. Improves error handling and logging

These changes ensure the workflow can properly update project board status when starting an implementation and when creating a PR.