### PR TITLE
Fix GraphQL query errors and label name in workflow

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -24,7 +24,7 @@ jobs:
           echo "ISSUE_TITLE=$ISSUE_TITLE" >> $GITHUB_ENV
           
           # Add "in_progress" label to issue if it exists
-          gh issue edit $ISSUE_NUMBER --add-label "in_progress" || echo "Label may not exist or already applied"
+          gh issue edit $ISSUE_NUMBER --add-label "in-progress" || echo "Label may not exist or already applied"
           
           # Update project board status
           if [ -n "${{ secrets.PROJECT_ID }}" ]; then
@@ -32,7 +32,7 @@ jobs:
             
             # Get item ID using GraphQL
             ITEM_ID=$(gh api graphql -f query='
-              query($org: String!, $number: Int!) {
+              query($org: String!) {
                 organization(login: $org) {
                   projectV2(number: ${{ secrets.PROJECT_ID }}) {
                     items(first: 100) {
@@ -56,7 +56,7 @@ jobs:
                     }
                   }
                 }
-              }' -f org="${{ github.repository_owner }}" -f number=$ISSUE_NUMBER --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '"$ISSUE_NUMBER"') | .id')
+              }' -f org="${{ github.repository_owner }}" --jq '.data.organization.projectV2.items.nodes[] | select(.content.number == '"$ISSUE_NUMBER"') | .id')
             
             if [ -z "$ITEM_ID" ]; then
               echo "Issue #$ISSUE_NUMBER not found in project board"


### PR DESCRIPTION
This PR fixes critical issues with the Claude implementation workflow:

1. Fixed GraphQL query error by removing the unused $number variable
   - Changed query($org: String\!, $number: Int\!) to simply query($org: String\!)
   - This eliminates the error: "Variable $number is declared by anonymous query but not used"

2. Fixed the label name issue
   - Changed in_progress to in-progress (with a hyphen instead of underscore)
   - This addresses the error: "in_progress not found"

These changes should allow the workflow to properly update project statuses without errors.
