### PR TITLE
Fix reaction triggering in workflow

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -3,15 +3,11 @@ name: Claude Issue Implementation
 on:
   issue_comment:
     types: [created]
-  issue_reaction:
-    types: [created]
 
 jobs:
   implement-issue:
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude-implement')) || 
-      (github.event_name == 'issue_reaction' && github.event.reaction.content == 'rocket')
+    if: contains(github.event.comment.body, '/claude-implement') || contains(github.event.comment.body, ':rocket:')
     permissions:
       contents: write
       pull-requests: write
@@ -22,15 +18,8 @@ jobs:
 
       - name: Get issue information and update status
         run: |
-          # Get issue number based on event type
-          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-          elif [[ "${{ github.event_name }}" == "issue_reaction" ]]; then
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-          else
-            echo "Unsupported event type: ${{ github.event_name }}"
-            exit 1
-          fi
+          # Get issue number from the comment event
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
           
           ISSUE_TITLE=$(gh issue view $ISSUE_NUMBER --json title -q .title)
           echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes the issue with the reaction triggering in the Claude implementation workflow.

## Changes
1. Removed the invalid  event trigger
2. Simplified the implementation to check for either '/claude-implement' or ':rocket:' in comments
3. Fixed the issue number extraction logic

These changes allow for triggering Claude via either:
- A comment with the command 
- A comment containing just the rocket emoji :rocket:

This approach ensures we stay within GitHub Actions' supported event types while still providing multiple ways to trigger Claude.