### PR TITLE
Add mcp__github__search_repositories to allowed tools

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/claude-code-action
         with:
           prompt_file: /tmp/claude-prompts/final-prompt.txt
-          allowed_tools: "Bash,Read,Write,Edit,Grep,mcp__github__get_issue,mcp__github__get_issue_comments"
+          allowed_tools: "Bash,Read,Write,Edit,Grep,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__search_repositories"
           install_github_mcp: "true"
           timeout_minutes: "30"
           anthropic_api_key: "${{ secrets.ANTHROPIC_API_KEY }}"


### PR DESCRIPTION
This PR adds the mcp__github__search_repositories tool to the allowed tools list to fix the permissions error when Claude tries to search repositories.